### PR TITLE
Fixed issues for pagination

### DIFF
--- a/src/main/java/com/raikuman/botutilities/buttons/pagination/buttondefaults/PageFirst.java
+++ b/src/main/java/com/raikuman/botutilities/buttons/pagination/buttondefaults/PageFirst.java
@@ -4,6 +4,7 @@ import com.raikuman.botutilities.buttons.manager.ButtonContext;
 import com.raikuman.botutilities.buttons.manager.ButtonInterface;
 import com.raikuman.botutilities.buttons.pagination.manager.PageInterface;
 import com.raikuman.botutilities.buttons.pagination.PaginationResources;
+import com.raikuman.botutilities.context.EventContext;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Emoji;
 import net.dv8tion.jda.api.requests.restaction.interactions.MessageEditCallbackAction;
@@ -13,7 +14,7 @@ import java.util.List;
 /**
  * Handles going to the first page of a pagination
  *
- * @version 1.0 2022-19-06
+ * @version 1.1 2022-19-06
  * @since 1.0
  */
 public class PageFirst implements ButtonInterface, PageInterface {
@@ -58,7 +59,7 @@ public class PageFirst implements ButtonInterface, PageInterface {
 	}
 
 	@Override
-	public List<EmbedBuilder> getPages(ButtonContext ctx) {
+	public List<EmbedBuilder> getPages(EventContext ctx) {
 		return null;
 	}
 

--- a/src/main/java/com/raikuman/botutilities/buttons/pagination/buttondefaults/PageHome.java
+++ b/src/main/java/com/raikuman/botutilities/buttons/pagination/buttondefaults/PageHome.java
@@ -3,6 +3,7 @@ package com.raikuman.botutilities.buttons.pagination.buttondefaults;
 import com.raikuman.botutilities.buttons.manager.ButtonContext;
 import com.raikuman.botutilities.buttons.manager.ButtonInterface;
 import com.raikuman.botutilities.buttons.pagination.manager.PageInterface;
+import com.raikuman.botutilities.context.EventContext;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Emoji;
 
@@ -11,7 +12,7 @@ import java.util.List;
 /**
  * Handles going to the initial page of a selection menu
  *
- * @version 1.0 2022-19-06
+ * @version 1.1 2022-19-06
  * @since 1.0
  */
 public class PageHome implements ButtonInterface, PageInterface {
@@ -43,7 +44,7 @@ public class PageHome implements ButtonInterface, PageInterface {
 	}
 
 	@Override
-	public List<EmbedBuilder> getPages(ButtonContext ctx) {
+	public List<EmbedBuilder> getPages(EventContext ctx) {
 		return null;
 	}
 

--- a/src/main/java/com/raikuman/botutilities/buttons/pagination/buttondefaults/PageLeft.java
+++ b/src/main/java/com/raikuman/botutilities/buttons/pagination/buttondefaults/PageLeft.java
@@ -4,6 +4,7 @@ import com.raikuman.botutilities.buttons.manager.ButtonContext;
 import com.raikuman.botutilities.buttons.manager.ButtonInterface;
 import com.raikuman.botutilities.buttons.pagination.manager.PageInterface;
 import com.raikuman.botutilities.buttons.pagination.PaginationResources;
+import com.raikuman.botutilities.context.EventContext;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Emoji;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
@@ -16,7 +17,7 @@ import java.util.List;
 /**
  * Handles going to the page left of a pagination
  *
- * @version 1.0 2022-19-06
+ * @version 1.1 2022-19-06
  * @since 1.0
  */
 public class PageLeft implements ButtonInterface, PageInterface {
@@ -40,6 +41,11 @@ public class PageLeft implements ButtonInterface, PageInterface {
 		if (loopPagination()) {
 			if (newPageNumber < 1)
 				newPageNumber = getPages(ctx).size();
+
+			if (newPageNumber == currentPageNumber) {
+				callbackAction.queue();
+				return;
+			}
 		} else {
 			if (newPageNumber == 1)
 				buttonList
@@ -73,7 +79,7 @@ public class PageLeft implements ButtonInterface, PageInterface {
 	}
 
 	@Override
-	public List<EmbedBuilder> getPages(ButtonContext ctx) {
+	public List<EmbedBuilder> getPages(EventContext ctx) {
 		return null;
 	}
 

--- a/src/main/java/com/raikuman/botutilities/buttons/pagination/buttondefaults/PageRight.java
+++ b/src/main/java/com/raikuman/botutilities/buttons/pagination/buttondefaults/PageRight.java
@@ -4,6 +4,7 @@ import com.raikuman.botutilities.buttons.manager.ButtonContext;
 import com.raikuman.botutilities.buttons.manager.ButtonInterface;
 import com.raikuman.botutilities.buttons.pagination.manager.PageInterface;
 import com.raikuman.botutilities.buttons.pagination.PaginationResources;
+import com.raikuman.botutilities.context.EventContext;
 import net.dv8tion.jda.api.EmbedBuilder;
 import net.dv8tion.jda.api.entities.Emoji;
 import net.dv8tion.jda.api.interactions.components.ActionRow;
@@ -16,7 +17,7 @@ import java.util.List;
 /**
  * Handles going to the page right of a pagination
  *
- * @version 1.0 2022-19-06
+ * @version 1.1 2022-19-06
  * @since 1.0
  */
 public class PageRight implements ButtonInterface, PageInterface {
@@ -40,6 +41,11 @@ public class PageRight implements ButtonInterface, PageInterface {
 		if (loopPagination()) {
 			if (newPageNumber > getPages(ctx).size())
 				newPageNumber = 1;
+
+			if (newPageNumber == currentPageNumber) {
+				callbackAction.queue();
+				return;
+			}
 		} else {
 			if (newPageNumber == getPages(ctx).size())
 				buttonList
@@ -73,7 +79,7 @@ public class PageRight implements ButtonInterface, PageInterface {
 	}
 
 	@Override
-	public List<EmbedBuilder> getPages(ButtonContext ctx) {
+	public List<EmbedBuilder> getPages(EventContext ctx) {
 		return null;
 	}
 

--- a/src/main/java/com/raikuman/botutilities/buttons/pagination/manager/PageInterface.java
+++ b/src/main/java/com/raikuman/botutilities/buttons/pagination/manager/PageInterface.java
@@ -1,6 +1,6 @@
 package com.raikuman.botutilities.buttons.pagination.manager;
 
-import com.raikuman.botutilities.buttons.manager.ButtonContext;
+import com.raikuman.botutilities.context.EventContext;
 import net.dv8tion.jda.api.EmbedBuilder;
 
 import java.util.List;
@@ -8,7 +8,7 @@ import java.util.List;
 /**
  * Provides an interface for pagination buttons
  *
- * @version 1.0 2022-19-06
+ * @version 1.1 2022-19-06
  * @since 1.0
  */
 public interface PageInterface {
@@ -18,7 +18,7 @@ public interface PageInterface {
 	 * @param ctx The button context to use to set embeds
 	 * @return The list of embed builders
 	 */
-	List<EmbedBuilder> getPages(ButtonContext ctx);
+	List<EmbedBuilder> getPages(EventContext ctx);
 
 	/**
 	 * Returns a boolean on whether to loop around a pagination

--- a/src/main/java/com/raikuman/botutilities/buttons/pagination/manager/PaginationBuilder.java
+++ b/src/main/java/com/raikuman/botutilities/buttons/pagination/manager/PaginationBuilder.java
@@ -44,7 +44,7 @@ public class PaginationBuilder {
 	public List<EmbedBuilder> buildEmbeds() {
 		return PaginationResources.buildEmbeds(
 			invoke,
-			member.getAvatarUrl(),
+			member.getEffectiveAvatarUrl(),
 			paginationStrings,
 			itemsPerPage
 		);

--- a/src/main/java/com/raikuman/botutilities/buttons/pagination/manager/PaginationButtonProvider.java
+++ b/src/main/java/com/raikuman/botutilities/buttons/pagination/manager/PaginationButtonProvider.java
@@ -1,6 +1,5 @@
 package com.raikuman.botutilities.buttons.pagination.manager;
 
-import com.raikuman.botutilities.buttons.manager.ButtonContext;
 import com.raikuman.botutilities.buttons.manager.ButtonInterface;
 import com.raikuman.botutilities.buttons.pagination.PaginationResources;
 import com.raikuman.botutilities.buttons.pagination.buttondefaults.PageFirst;
@@ -8,18 +7,18 @@ import com.raikuman.botutilities.buttons.pagination.buttondefaults.PageHome;
 import com.raikuman.botutilities.buttons.pagination.buttondefaults.PageLeft;
 import com.raikuman.botutilities.buttons.pagination.buttondefaults.PageRight;
 import com.raikuman.botutilities.commands.manager.CommandInterface;
+import com.raikuman.botutilities.context.EventContext;
 import net.dv8tion.jda.api.EmbedBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 /**
  * A button provider for pagination to offer button interfaces to the button manager
  *
- * @version 1.1 2022-19-06
+ * @version 1.2 2022-19-06
  * @since 1.0
  */
 public class PaginationButtonProvider {
@@ -60,14 +59,12 @@ public class PaginationButtonProvider {
 			return new ArrayList<>();
 		}
 
-		List<ButtonInterface> buttonInterfaces = Arrays.asList(
+		List<ButtonInterface> buttonInterfaces = new ArrayList<>();
+		buttonInterfaces.add(
 			new PageLeft(command.getInvoke()) {
 
 				@Override
-				public List<EmbedBuilder> getPages(ButtonContext ctx) {
-					if (ctx.getEvent().getGuild() == null)
-						return null;
-
+				public List<EmbedBuilder> getPages(EventContext ctx) {
 					return PaginationResources.buildEmbeds(
 						command.getInvoke(),
 						ctx.getEventMember().getAvatarUrl(),
@@ -80,14 +77,14 @@ public class PaginationButtonProvider {
 				public boolean loopPagination() {
 					return pageCommandInterface.loopPagination();
 				}
-			},
+			}
+		);
+
+		buttonInterfaces.add(
 			new PageRight(command.getInvoke()) {
 
 				@Override
-				public List<EmbedBuilder> getPages(ButtonContext ctx) {
-					if (ctx.getEvent().getGuild() == null)
-						return null;
-
+				public List<EmbedBuilder> getPages(EventContext ctx) {
 					return PaginationResources.buildEmbeds(
 						command.getInvoke(),
 						ctx.getEventMember().getAvatarUrl(),
@@ -109,10 +106,7 @@ public class PaginationButtonProvider {
 				new PageHome(command.getInvoke()) {
 
 					@Override
-					public List<EmbedBuilder> getPages(ButtonContext ctx) {
-						if (ctx.getEvent().getGuild() == null)
-							return null;
-
+					public List<EmbedBuilder> getPages(EventContext ctx) {
 						return PaginationResources.buildEmbeds(
 							command.getInvoke(),
 							ctx.getEventMember().getAvatarUrl(),
@@ -134,10 +128,7 @@ public class PaginationButtonProvider {
 				new PageFirst(command.getInvoke()) {
 
 					@Override
-					public List<EmbedBuilder> getPages(ButtonContext ctx) {
-						if (ctx.getEvent().getGuild() == null)
-							return null;
-
+					public List<EmbedBuilder> getPages(EventContext ctx) {
 						return PaginationResources.buildEmbeds(
 							command.getInvoke(),
 							ctx.getEventMember().getAvatarUrl(),


### PR DESCRIPTION
## Additions
- All types of events should implement the interface EventContext so that events can be deduced through different types of managers.

## Fixes
- Single page paginations no longer edit the embed
- Getting the user's avatar url from the event's member